### PR TITLE
Fix mapping of arrays with transform function

### DIFF
--- a/src/object-mapper-async.js
+++ b/src/object-mapper-async.js
@@ -115,7 +115,7 @@ async function updateArrIx(dest, ix, data, keys, context) {
     typeof dest[ix] !== "undefined"
   )
     o = keys.length ? await update(dest[ix], data, keys, context) : data;
-  else o = keys.length ? await update(null, data, keys, context) : data;
+  else o = keys.length ? await update(null, data, keys, context) : applyTransform(data, dest, context);
 
   // Only update (and create if needed) dest if there is data to be saved
   if (o !== null) {
@@ -160,7 +160,7 @@ async function updateArr(dest, key, data, keys, context) {
         return await updateArrIx(
           await dest,
           i,
-          await applyTransform(d, dest, context),
+          d,
           keys.slice(),
           context
         );

--- a/test/test.js
+++ b/test/test.js
@@ -2270,4 +2270,35 @@ describe("Object Mapper Async", () => {
     const result = await om(src, map);
     expect(result).toEqual(expected);
   });
+
+  it("map array with function", async () => {
+    var obj = {
+      theArray: [
+        {text:"textvalue"},
+        {text:"text"}
+      ]
+    };
+
+    var expect = {
+      newArray: [
+        {textSize:9},
+        {textSize:4}
+      ]
+    };
+
+    let transformFunc = {
+      key:'newArray[].textSize',
+      transform: function (value, src, dest, srcKey, destKey){
+        return value.length
+      }
+    };
+    var map = {
+      'theArray[].text': transformFunc
+    };
+
+    var result = om(obj, map);
+
+    t.deepEqual(result, expect);
+    t.end();
+  });
 });


### PR DESCRIPTION
Within the original node-object mapper there is [issue #77](https://github.com/wankdanker/node-object-mapper/issues/77) where when applying a transformation to an array the previous value of the transformation will be passed to the input of the next iteration of the transform. This PR is a copy of an [existing open PR](https://github.com/wankdanker/node-object-mapper/pull/90) to node-object-mapper that has been stagnant for a year. 